### PR TITLE
build(gimp): add "glib-networking" as dependency

### DIFF
--- a/gimp-stripped/PKGBUILD
+++ b/gimp-stripped/PKGBUILD
@@ -65,6 +65,7 @@ makedepends=(
     'intltool'
 
     'iso-codes'
+    'glib-networking'
 )
 optdepends=(
     'alsa-lib: for MIDI event controller module'


### PR DESCRIPTION
while the package is usually installed alongside DE, a minimal arch container needs to install it to build