### PR TITLE
build(gimp): add "libxslt" to makedepends

### DIFF
--- a/gimp-stripped/.SRCINFO
+++ b/gimp-stripped/.SRCINFO
@@ -9,6 +9,7 @@ pkgbase = gimp-stripped
 	makedepends = iso-codes
 	makedepends = glib-networking
 	makedepends = glib2-devel
+	makedepends = libxslt
 	depends = babl
 	depends = gegl
 	depends = gtk2

--- a/gimp-stripped/PKGBUILD
+++ b/gimp-stripped/PKGBUILD
@@ -17,6 +17,7 @@ makedepends=(
     'iso-codes'
     'glib-networking'
     'glib2-devel'
+    'libxslt'
 )
 depends=(
     # core deps


### PR DESCRIPTION
required to build the /menus XML files

```
Making all in menus
make[2]: Entering directory '/__w/gimp-stripped/gimp-stripped/pkgbuilds/gimp-stripped/src/gimp-2.10.38/menus'
*** xsltproc is required to build the menus XML files ***
make[2]: *** [Makefile:855: dockable-menu.xml] Error 1
```