### PR TITLE
gimp-stripped: enable-console-bin

### DIFF
--- a/gimp-stripped/PKGBUILD
+++ b/gimp-stripped/PKGBUILD
@@ -100,7 +100,6 @@ build() {
         --prefix=/usr
         --sysconfdir=/etc
         --libexecdir=/usr/bin
-        -Denable-console-bin=false
         -Dbug-report-url='https://github.com/mrdotx/pkgbuilds/issues'
         -Dcheck-update=no
         -Dlibunwind=false


### PR DESCRIPTION
required for gimp-data/images/ in headless container.

```
[2523/2535] Generating gimp-data/images/gimp-splash.png with a custom command (wrapped by meson to set env, to feed input)
FAILED: gimp-data/images/gimp-splash.png 
/usr/sbin/meson --internal exe --unpickle /__w/gimp-stripped/gimp-stripped/pkgbuilds/gimp-stripped/src/build/meson-private/meson_exe_in-build-gimp.sh_dd132fec928e252d50e7397561da2b09167d9efc.dat
while executing ['/__w/gimp-stripped/gimp-stripped/pkgbuilds/gimp-stripped/src/gimp-3.0.0/tools/in-build-gimp.sh', '-nidfs', '../gimp-3.0.0/gimp-data/images/gimp-splash.xcf.xz', '--batch-interpreter', 'python-fu-eval', '-b', '-', '--quit']
--- stdout ---
INFO: temporary GIMP configuration directory: /__w/gimp-stripped/gimp-stripped/pkgbuilds/gimp-stripped/src/build/.GIMP3-build-config-fCBLC2
RUNNING: cat /dev/stdin | /__w/gimp-stripped/gimp-stripped/pkgbuilds/gimp-stripped/src/build/app/gimp-3.0 -nidfs ../gimp-3.0.0/gimp-data/images/gimp-splash.xcf.xz --batch-interpreter python-fu-eval -b - --quit
Cannot open display: 
```

Seems like [a bug](https://gitlab.gnome.org/GNOME/gimp/-/issues/12042) in v3, tried [the patch](https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/2094) but didn't work.