### PR TITLE
gimp-stripped: add glibc-locales makedep

### DIFF
--- a/gimp-stripped/.SRCINFO
+++ b/gimp-stripped/.SRCINFO
@@ -6,6 +6,7 @@ pkgbase = gimp-stripped
 	arch = x86_64
 	license = GPL-3.0-or-later
 	makedepends = glib2-devel
+	makedepends = glibc-locales
 	makedepends = gobject-introspection
 	makedepends = intltool
 	makedepends = libxslt

--- a/gimp-stripped/PKGBUILD
+++ b/gimp-stripped/PKGBUILD
@@ -15,6 +15,7 @@ makedepends=(
     #'gi-docgen'
     #'gjs'
     'glib2-devel'
+    'glibc-locales'
     'gobject-introspection'
     #'gtk-doc'
     #'gvfs'


### PR DESCRIPTION
required by `setlocale()` in tools/gen-languages.c
headless arch container doesn't ship with glibc-locales.

```
FAILED: [code=1] app/widgets/gimplanguagestore-data.h 
/__w/gimp-stripped/gimp-stripped/pkgbuilds/gimp-stripped/src/build/tools/gen-languages
ERROR: ../gimp-3.0.8/tools/gen-languages.c: setlocale() failed. The build system needs to be set up for localization. Please install at least "en_US.UTF-8" or set a locale other than C or POSIX.
```